### PR TITLE
fix: Remove unnecessary blank line in Docker Compose files for `FrankenPHP` and `Nginx` services.

### DIFF
--- a/docker-compose.frankenphp.yml
+++ b/docker-compose.frankenphp.yml
@@ -1,4 +1,3 @@
-
 services:
   yii2-frankenphp:
     build:

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -1,4 +1,3 @@
-
 services:
   yii2-nginx:
     build:


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed unnecessary blank lines at the beginning of Docker Compose configuration files for improved formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->