### PR TITLE
refactor: Update Docker configurations to use named volumes for Composer cache, improving consistency across services.

### DIFF
--- a/docker-compose.frankenphp.yml
+++ b/docker-compose.frankenphp.yml
@@ -23,12 +23,13 @@ services:
     restart: always
     volumes:
       - ./:/app
-      - ${HOME}/.composer-docker/cache:/var/www/.composer/cache:delegated
-      - caddy_data:/data
       - caddy_config:/config
+      - caddy_data:/data
+      - composer_cache:/var/www/.composer/cache
     working_dir: /app
     tty: true
 
 volumes:
   caddy_data:
   caddy_config:
+  composer_cache:

--- a/docker-compose.frankenphp.yml
+++ b/docker-compose.frankenphp.yml
@@ -33,3 +33,4 @@ volumes:
   caddy_data:
   caddy_config:
   composer_cache:
+    external: true

--- a/docker-compose.frankenphp.yml
+++ b/docker-compose.frankenphp.yml
@@ -33,4 +33,3 @@ volumes:
   caddy_data:
   caddy_config:
   composer_cache:
-    external: true

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -28,4 +28,3 @@ services:
 
 volumes:
   composer_cache:
-    external: true

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -22,6 +22,9 @@ services:
     restart: always
     volumes:
       - ./:/app
-      - ${HOME}/.composer-docker/cache:/var/www/.composer/cache:delegated
+      - composer_cache:/var/www/.composer/cache
     working_dir: /app
     tty: true
+
+volumes:
+  composer_cache:

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -28,3 +28,4 @@ services:
 
 volumes:
   composer_cache:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,4 +28,3 @@ services:
 
 volumes:
   composer_cache:
-    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ services:
     restart: always
     volumes:
       - ./:/app
-      - ${HOME}/.composer-docker/cache:/var/www/.composer/cache:delegated
+      - composer_cache:/var/www/.composer/cache
     working_dir: /app
     tty: true
+
+volumes:
+  composer_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,4 @@ services:
 
 volumes:
   composer_cache:
+    external: true


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configurations to use a managed Docker volume for Composer cache instead of a host directory. This change applies to all relevant services and improves portability and consistency across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->