### PR TITLE
fix: Correct indentation in Caddyfile for TCP socket comment.

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -11,7 +11,7 @@ https://localhost:443 {
     # Document root
     root * /app/public
 
-+   # Using TCP socket for improved compatibility across environments
+    # Using TCP socket for improved compatibility across environments
     php_fastcgi 127.0.0.1:9000 {
         index index.php
         try_files {path} {path}/index.php =404


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌
