### PR TITLE
fix: Add `.editorconfig` and `c3.php` to export-ignore list in `.gitattributes`.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,11 +26,13 @@
 /CHANGELOG.md		merge=union
 
 # Exclude files from the archive
+/.editorconfig                  export-ignore
 /.gitattributes                 export-ignore
 /.github                        export-ignore
 /.gitignore                     export-ignore
 /.phpstan.neon                  export-ignore
 /.styleci.yml                   export-ignore
+/c3.php                         export-ignore
 /codeception.yml                export-ignore
 /composer-require-checker.json  export-ignore
 /composer.lock                  export-ignore


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated packaging configuration to omit non-essential development and test artifacts from generated archives. This results in leaner downloads, faster transfers, and fewer extraneous files in distributed bundles. No impact on app behavior or runtime functionality. Installations and deployments remain unchanged; only the contents of exported archives are affected. This helps streamline distribution for end users and downstream integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->