### PR TITLE
fix: Update export-ignore list in `.gitattributes` to streamline archive contents.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,19 +26,10 @@
 /CHANGELOG.md		merge=union
 
 # Exclude files from the archive
-/.editorconfig                  export-ignore
 /.gitattributes                 export-ignore
 /.github                        export-ignore
 /.gitignore                     export-ignore
-/.phpstan.neon                  export-ignore
 /.styleci.yml                   export-ignore
-/c3.php                         export-ignore
-/codeception.yml                export-ignore
-/composer-require-checker.json  export-ignore
 /composer.lock                  export-ignore
 /docs                           export-ignore
-/ecs.php                        export-ignore
-/phpstan.neon*                  export-ignore
 /psalm.xml                      export-ignore
-/rector.php                     export-ignore
-/tests                          export-ignore


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌
