### PR TITLE
fix: Move badges for latest stable version and total downloads in `README.md` to `Installation` section.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.1.1 Under development
 
+- Bug #140: Move badges for latest stable version and total downloads in `README.md` to `Installation` section (@terabytesoftw)
+
 ## 0.1.0 August 31, 2025
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ The Yii2 Web Application Basic template provides a complete foundation for build
 
 ### Installation
 
+[![Latest Stable Version](https://img.shields.io/packagist/v/yii2-extensions/app-basic.svg?style=for-the-badge&logo=packagist&logoColor=white&label=Stable)](https://packagist.org/packages/yii2-extensions/app-basic)
+[![Total Downloads](https://img.shields.io/packagist/dt/yii2-extensions/app-basic.svg?style=for-the-badge&logo=packagist&logoColor=white&label=Downloads)](https://packagist.org/packages/yii2-extensions/app-basic)
+
 **Quick start**
 
 ```bash
@@ -137,8 +140,6 @@ final class SiteController extends Controller
 ```
 ## Quality code
 
-[![Latest Stable Version](https://img.shields.io/packagist/v/yii2-extensions/app-basic.svg?style=for-the-badge&logo=packagist&logoColor=white&label=Stable)](https://packagist.org/packages/yii2-extensions/app-basic)
-[![Total Downloads](https://img.shields.io/packagist/dt/yii2-extensions/app-basic.svg?style=for-the-badge&logo=packagist&logoColor=white&label=Downloads)](https://packagist.org/packages/yii2-extensions/app-basic)
 [![Codecov](https://img.shields.io/codecov/c/github/yii2-extensions/app-basic.svg?branch=main&style=for-the-badge&logo=codecov&logoColor=white&label=Coverage)](https://codecov.io/github/yii2-extensions/app-basic)
 [![PHPStan Level Max](https://img.shields.io/badge/PHPStan-Level%20Max-4F5D95.svg?style=for-the-badge&logo=php&logoColor=white)](https://github.com/yii2-extensions/app-basic/actions/workflows/static.yml)
 [![StyleCI](https://img.shields.io/badge/StyleCI-Passed-44CC11.svg?style=for-the-badge&logo=styleci&logoColor=white)](https://github.styleci.io/repos/165419144?branch=main)


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Relocated Packagist badges (Latest Stable Version and Total Downloads) to the Installation section.
  * Removed the same badges from the Quality code section to avoid duplication.
  * Updated the changelog with an entry under version 0.1.1 (under development) reflecting these documentation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->