### PR TITLE
fix(app): Add `Available stacks` section with `RoadRunner` badge to `README.md`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.1 Under development
 
 - Bug #140: Move badges for latest stable version and total downloads in `README.md` to `Installation` section (@terabytesoftw)
+- Bug #143: Add `Available stacks` section with `RoadRunner` badge to `README.md` (@terabytesoftw)
 
 ## 0.1.0 August 31, 2025
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ A modern, Bootstrap 5-powered Yii2 application template designed for rapid web-a
 - ✅ **Modern Bootstrap 5 UI** - Responsive, mobile-first design with latest Bootstrap components.
 - ✅ **Testing Ready** - Codeception test suite with examples for functional and unit testing.
 
+## Available stacks
+
+[![RoadRunner Worker](https://img.shields.io/badge/road%20runner-%23FF6B35.svg?style=for-the-badge&label=worker&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDJMMjIgMTJMMTIgMjJMMiAxMkwxMiAyWiIgZmlsbD0iI0ZGNkIzNSIvPgo8cGF0aCBkPSJNMTIgNkwxOCAxMkwxMiAxOEw2IDEyTDEyIDZaIiBmaWxsPSIjRkZGRkZGIi8+CjxwYXRoIGQ9Ik0xMiA5TDE1IDEyTDEyIDE1TDkgMTJMMTIgOVoiIGZpbGw9IiNGRjZCMzUiLz4KPC9zdmc+&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/road-runner)
+
 ## Quick start
 
 ### How it works

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ A modern, Bootstrap 5-powered Yii2 application template designed for rapid web-a
 
 [![RoadRunner Worker](https://img.shields.io/badge/road%20runner-%23FF6B35.svg?style=for-the-badge&label=worker&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDJMMjIgMTJMMTIgMjJMMiAxMkwxMiAyWiIgZmlsbD0iI0ZGNkIzNSIvPgo8cGF0aCBkPSJNMTIgNkwxOCAxMkwxMiAxOEw2IDEyTDEyIDZaIiBmaWxsPSIjRkZGRkZGIi8+CjxwYXRoIGQ9Ik0xMiA5TDE1IDEyTDEyIDE1TDkgMTJMMTIgOVoiIGZpbGw9IiNGRjZCMzUiLz4KPC9zdmc+&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/road-runner)
 
+For setup instructions, see README in each branch.
+
 ## Quick start
 
 ### How it works


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Available stacks" section to the README showcasing supported stacks and including a RoadRunner Worker badge linking to the road-runner branch; placed after the "Testing Ready" feature with proper spacing.
  * Updated CHANGELOG (0.1.1) to record this documentation addition. No functional or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->