### PR TITLE
fix(docs): Remove redundant `Quick start` section header from `READMEmd`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bug #149: Update PHPStan annotations and add container configuration file (@terabytesoftw)
 - Bug #150: Add container configuration to `console` app setup (@terabytesoftw)
 - Enh #151: Implement `FrankenPHP` stack (@terabytesoftw)
+- Bug #152: Remove redundant `Quick start` section header from `README.md` (@terabytesoftw)
 
 ## 0.1.0 August 31, 2025
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ A modern, Bootstrap 5-powered Yii2 application template designed for rapid web-a
 - ✅ **Modern Bootstrap 5 UI** - Responsive, mobile-first design with latest Bootstrap components.
 - ✅ **Testing Ready** - Codeception test suite with examples for functional and unit testing.
 
-## Quick start
-
 ### How it works
 
 The Yii2 Web Application Basic template provides a complete foundation for building modern web applications. Unlike starting 
@@ -73,7 +71,7 @@ composer create-project --prefer-dist yii2-extensions/app-basic:dev-franken-php 
 cd app-basic
 ```
 
-**Quick start**
+### Quick start
 
 Download static cli in Linux/WSL2
 


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌
