### PR TITLE
fix(app): Remove redundant `Basic usage` section from `README.md`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bug #149: Update PHPStan annotations and add container configuration file (@terabytesoftw)
 - Bug #150: Add container configuration to `console` app setup (@terabytesoftw)
 - Bug #156: Update `README.md` with new Packagist badges and improve structure (@terabytesoftw)
+- Bug #159: Remove redundant `Basic usage` section from `README.md` (@terabytesoftw)
 
 ## 0.1.0 August 31, 2025
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ php -S localhost:8080 -t web
 
 > Your application will be available at `http://localhost:8080` or at the address set in `--address` option.
 
-### Basic usage
-
 #### Directory structure
 
 ```text


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌
