### PR TITLE
fix(app): Update section title `Available stacks` and improve badge formatting in `README.md`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bug #156: Update `README.md` with new Packagist badges and improve structure (@terabytesoftw)
 - Bug #159: Remove redundant `Basic usage` section from `README.md` (@terabytesoftw)
 - Bug #162: Update `README.md` to reorganize `Package information` and add latest stable version badge (@terabytesoftw)
+- Bug #167: Update section title `Available stacks` and improve badge formatting in `README.md` (@terabytesoftw)
 
 ## 0.1.0 August 31, 2025
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ A modern, Bootstrap 5-powered Yii2 application template designed for rapid web-a
 - ✅ **Modern Bootstrap 5 UI** - Responsive, mobile-first design with latest Bootstrap components.
 - ✅ **Testing Ready** - Codeception test suite with examples for functional and unit testing.
 
-## Available stacks
+## Available worker mode stacks
 
-[![FrankenPHP Worker](https://img.shields.io/badge/frankenphp-blue?style=for-the-badge&label=worker&logo=php&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/franken-php)
-[![RoadRunner Worker](https://img.shields.io/badge/road%20runner-%23FF6B35.svg?style=for-the-badge&label=worker&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDJMMjIgMTJMMTIgMjJMMiAxMkwxMiAyWiIgZmlsbD0iI0ZGNkIzNSIvPgo8cGF0aCBkPSJNMTIgNkwxOCAxMkwxMiAxOEw2IDEyTDEyIDZaIiBmaWxsPSIjRkZGRkZGIi8+CjxwYXRoIGQ9Ik0xMiA5TDE1IDEyTDEyIDE1TDkgMTJMMTIgOVoiIGZpbGw9IiNGRjZCMzUiLz4KPC9zdmc+&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/road-runner)
+[![FrankenPHP](https://img.shields.io/badge/FrankenPHP-777BB4?style=for-the-badge&logo=php&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/franken-php)
+[![RoadRunner](https://img.shields.io/badge/RoadRunner-%23FF6B35.svg?style=for-the-badge&logo=rocket&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/road-runner)
 
 For setup instructions, see README in each branch.
 


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Renamed the “Available stacks” section to “Available worker mode stacks” for clarity.
  - Updated badges to use FrankenPHP and RoadRunner branding, removing “Worker” labels while keeping existing links.
  - Added a changelog entry under the “0.1.1 Under development” section noting these documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->