### PR TITLE
fix(app): Update section title to `Available deployment options` and add descriptions for server stacks in `README.md`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Bug #159: Remove redundant `Basic usage` section from `README.md` (@terabytesoftw)
 - Bug #162: Update `README.md` to reorganize `Package information` and add latest stable version badge (@terabytesoftw)
 - Bug #167: Update section title `Available stacks` and improve badge formatting in `README.md` (@terabytesoftw)
-- Bug #171: Update section title to `Available deployment options` and add descriptions for server stacks in `README.md` (@terabytesoftw)
+- Bug #171: Update section title to `Available deployment options`, group stacks by type, and add Apache entry in `README.md` (@terabytesoftw)
 
 ## 0.1.0 August 31, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bug #159: Remove redundant `Basic usage` section from `README.md` (@terabytesoftw)
 - Bug #162: Update `README.md` to reorganize `Package information` and add latest stable version badge (@terabytesoftw)
 - Bug #167: Update section title `Available stacks` and improve badge formatting in `README.md` (@terabytesoftw)
+- Bug #171: Update section title to `Available deployment options` and add descriptions for server stacks in `README.md` (@terabytesoftw)
 
 ## 0.1.0 August 31, 2025
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,16 @@ A modern, Bootstrap 5-powered Yii2 application template designed for rapid web-a
 - ✅ **Modern Bootstrap 5 UI** - Responsive, mobile-first design with latest Bootstrap components.
 - ✅ **Testing Ready** - Codeception test suite with examples for functional and unit testing.
 
-## Available worker mode stacks
+## Available deployment options
+
+**Traditional Web Servers**
+
+[![Apache](https://img.shields.io/badge/apache-%23D42029.svg?style=for-the-badge&logo=apache&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/apache)
+
+**High-Performance Worker Mode**
 
 [![FrankenPHP](https://img.shields.io/badge/FrankenPHP-777BB4?style=for-the-badge&logo=php&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/franken-php)
-[![RoadRunner](https://img.shields.io/badge/RoadRunner-%23FF6B35.svg?style=for-the-badge&logo=rocket&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/road-runner)
+[![RoadRunner](https://img.shields.io/badge/RoadRunner-%23FF6B35.svg?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDJMMjIgMTJMMTIgMjJMMiAxMkwxMiAyWiIgZmlsbD0iI0ZGRkZGRiIvPgo8cGF0aCBkPSJNOCAyTDE2IDEwTDggMThaIiBmaWxsPSIjRkY2QjM1Ii8+CjxwYXRoIGQ9Ik0xNiA2TDIwIDEwTDE2IDE0WiIgZmlsbD0iI0ZGNkIzNSIvPgo8L3N2Zz4K&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/road-runner)
 
 For setup instructions, see README in each branch.
 

--- a/README.md
+++ b/README.md
@@ -42,16 +42,20 @@ A modern, Bootstrap 5-powered Yii2 application template designed for rapid web-a
 
 ## Available deployment options
 
-**Traditional Web Servers**
+### Traditional Web Servers
+
+Classic request-per-process model; simple, widely supported (for example, Apache).
 
 [![Apache](https://img.shields.io/badge/apache-%23D42029.svg?style=for-the-badge&logo=apache&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/apache)
 
-**High-Performance Worker Mode**
+### High-Performance Worker Mode
+
+Long-running PHP workers for higher throughput and lower latency.
 
 [![FrankenPHP](https://img.shields.io/badge/FrankenPHP-777BB4?style=for-the-badge&logo=php&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/franken-php)
 [![RoadRunner](https://img.shields.io/badge/RoadRunner-%23FF6B35.svg?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDJMMjIgMTJMMTIgMjJMMiAxMkwxMiAyWiIgZmlsbD0iI0ZGRkZGRiIvPgo8cGF0aCBkPSJNOCAyTDE2IDEwTDggMThaIiBmaWxsPSIjRkY2QjM1Ii8+CjxwYXRoIGQ9Ik0xNiA2TDIwIDEwTDE2IDE0WiIgZmlsbD0iI0ZGNkIzNSIvPgo8L3N2Zz4K&logoColor=white)](https://github.com/yii2-extensions/app-basic/tree/road-runner)
 
-For setup instructions, see README in each branch.
+> For setup instructions, see `README.md` in each branch.
 
 ## How it works
 

--- a/config/web/modules.php
+++ b/config/web/modules.php
@@ -6,12 +6,12 @@ $config = [
     'debug' => [
         'class' => yii\debug\Module::class,
         // uncomment the following to add your IP if you aren't connecting from localhost.
-        //'allowedIPs' => ['127.0.0.1', '::1'],
+        'allowedIPs' => ['*'], // allow all IPs for development purposes only, do not use in production
     ],
     'gii' => [
         'class' => yii\gii\Module::class,
         // uncomment the following to add your IP if you aren't connecting from localhost.
-        //'allowedIPs' => ['127.0.0.1', '::1'],
+        'allowedIPs' => ['*'], // allow all IPs for development purposes only, do not use in production
     ],
 ];
 


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Development tools now accessible from any IP by default, simplifying setup (intended for development only).

- Documentation
  - Renamed “Available worker mode stacks” to “Available deployment options”.
  - Added “Traditional Web Servers” subsection with Apache option.
  - Updated RoadRunner badge to an inline graphic; other deployment entries unchanged.
  - Made setup instruction line a blockquote and added a changelog entry under 0.1.1.

- Chores
  - Relaxed IP restrictions for development modules to allow access from all IPs (do not use in production).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->