### PR TITLE
fix(app): Add missing config path to ECS configuration in `ecs.php`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Bug #171: Update section title to `Available deployment options`, group stacks by type, and add Apache entry in `README.md` (@terabytesoftw)
 - Bug #172: Update badge label from `PHPUnit` to `Codeception` in `README.md` (@terabytesoftw)
 - Bug #175: Update allowed IPs in configuration for development purposes in `configuration.md` (@terabytesoftw)
+- Bug #177: Add missing config path to ECS configuration in `ecs.php` (@terabytesoftw)
 
 ## 0.1.0 August 31, 2025
 

--- a/ecs.php
+++ b/ecs.php
@@ -48,6 +48,7 @@ return Symplify\EasyCodingStandard\Config\ECSConfig::configure()
     ->withFileExtensions(['php'])
     ->withPaths(
         [
+            __DIR__ . '/config',
             __DIR__ . '/src',
             __DIR__ . '/tests',
         ],


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌
