### PR TITLE
fix(docs): Correct typo in Codeception build step name in `build.yml`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout.
         uses: actions/checkout@v5
 
-      - name: Show docker version.
+      - name: Docker version.
         run: |
           docker version
           docker compose version
@@ -45,5 +45,5 @@ jobs:
       - name: Codeception build.
         run: docker exec yii2-nginx vendor/bin/codecept build
 
-      - name: Run codeception tests.
+      - name: Codeception tests.
         run: docker exec yii2-nginx vendor/bin/codecept run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           done
           echo "Service not ready"; docker logs yii2-nginx; exit 1
 
-      - name: Codeceptcion build.
+      - name: Codeception build.
         run: docker exec yii2-nginx vendor/bin/codecept build
 
       - name: Run codeception tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Enh #181: Implement `Nginx` stack (@terabytesoftw)
 - Bug #182: Improve clarity in deployment options description and add `Nginx` badge in `README.md` (@terabytesoftw)
 - Bug #183: Update badge links in `README.md` to include branch query for `nginx` (@terabytesoftw)
+- Bug #185: Correct typo in Codeception build step name in `build.yml` (@terabytesoftw)
 
 ## 0.1.0 August 31, 2025
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ final class SiteController extends Controller
 ## Quality code
 
 [![Codecov](https://img.shields.io/codecov/c/github/yii2-extensions/app-basic.svg?branch=nginx&style=for-the-badge&logo=codecov&logoColor=white&label=Coverage)](https://codecov.io/github/yii2-extensions/app-basic)
-[![PHPStan Level Max](https://img.shields.io/badge/PHPStan-Level%20Max-4F5D95.svg?style=for-the-badge&logo=php&logoColor=white)](https://github.com/yii2-extensions/app-basic/actions/workflows/static.yml)
+[![PHPStan Level Max](https://img.shields.io/badge/PHPStan-Level%20Max-4F5D95.svg?style=for-the-badge&logo=php&logoColor=white)](https://github.com/yii2-extensions/app-basic/actions/workflows/static.yml?query=branch%3Anginx)
 [![StyleCI](https://img.shields.io/badge/StyleCI-Passed-44CC11.svg?style=for-the-badge&logo=styleci&logoColor=white)](https://github.styleci.io/repos/165419144?branch=nginx)
 
 ## Documentation


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected a typo in the CI step name (“Codeception build”) to display the correct label in build logs; no functional changes to the workflow.

- Documentation
  - Updated CHANGELOG (0.1.1 Under development) to record the fix.
  - Refreshed README’s PHPStan badge link to point to the nginx branch query, improving badge accuracy and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->