### PR TITLE
fix(ci): Remove unnecessary Docker version checks and readiness wait from build workflow; add healthcheck to docker-compose configuration.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,22 +25,8 @@ jobs:
       - name: Checkout.
         uses: actions/checkout@v5
 
-      - name: Docker version.
-        run: |
-          docker version
-          docker compose version
-
       - name: Build and start containers.
-        run: docker compose up -d --build
-
-      - name: Wait for readiness.
-        run: |
-          for i in {1..60}; do
-            if docker exec yii2-nginx sh -lc "curl -ksS -o /dev/null -w '%{http_code}' https://localhost | grep -qE '200|302'"; then
-              echo "Service is ready"; exit 0; fi
-            sleep 2
-          done
-          echo "Service not ready"; docker logs yii2-nginx; exit 1
+        run: docker compose up -d --build --wait
 
       - name: Codeception build.
         run: docker exec yii2-nginx vendor/bin/codecept build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Bug #182: Improve clarity in deployment options description and add `Nginx` badge in `README.md` (@terabytesoftw)
 - Bug #183: Update badge links in `README.md` to include branch query for `nginx` (@terabytesoftw)
 - Bug #185: Correct typo in Codeception build step name in `build.yml` (@terabytesoftw)
+- Bug #189: Remove unnecessary Docker version checks and readiness wait from build workflow; add healthcheck to docker-compose configuration (@terabytesoftw)
 
 ## 0.1.0 August 31, 2025
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,12 @@ services:
       TZ: "UTC"
       YII_DEBUG: "${YII_DEBUG:-false}"
       YII_ENV: "${YII_ENV:-prod}"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
     ports:
       - '8080:80'
       - '8443:443'


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌
