### PR TITLE
fix(docs): Update installation command to use the `dev-franken-php-classic` version in `README.md`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Bug #177: Add missing config path to ECS configuration in `ecs.php` (@terabytesoftw)
 - Bug #182: Improve clarity in deployment options description and add `Nginx` badge in `README.md` (@terabytesoftw)
 - Bug #188: Update `README.md` to include `FrankenPHP` badge for classic web server setup (@terabytesoftw)
+- Bug #190: Update installation command to use the `dev-franken-php-classic` version in `README.md` (@terabytesoftw)
 
 ## 0.1.0 August 31, 2025
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The Yii2 Web Application Basic template provides a complete foundation for build
 ### Installation
 
 ```bash
-composer create-project --prefer-dist yii2-extensions/app-basic:^0.1 app-basic
+composer create-project --prefer-dist yii2-extensions/app-basic:dev-franken-php-classic app-basic
 cd app-basic
 ```
 


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Is bugfix    | ✔️
| New feature  | ❌
| Breaks BC    | ❌
