### PR TITLE
feat(linters): Add `.codespellrc` configuration to skip specific files and directories for spell checking.

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = */tests/*,tests/**,*/composer.lock,*/composer.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bug #223: Remove outdated composer asset dependencies from `package.json` (@terabytesoftw)
 - Enh #229: Add `php-forge/coding-standard` to development dependencies for code quality checks (@terabytesoftw)
 - Bug #230: Add section for automated refactoring using `Rector` in testing documentation (@terabytesoftw)
+- Enh #236: Add `.codespellrc` configuration to skip specific files and directories for spell checking (@terabytesoftw)
 
 ## 0.1.2 October 8, 2025
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
